### PR TITLE
INFRA-7456 resend messages only when CB is ready

### DIFF
--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -89,7 +89,7 @@ func (p *T) ReSend() {
 	for _ = range ticker.C {
 		p.resendMutex.Lock()
 		if p.cb.State() == gobreaker.StateClosed {
-			p.Logger.Info("Running resend, as CB is not tripped")
+			p.Logger.Info("Running resend, as CB is not open")
 			now := time.Now().Unix()
 			for r := range p.wal.Iterate() {
 				rtime, err := wal.GetTime(r)
@@ -107,7 +107,7 @@ func (p *T) ReSend() {
 			p.Logger.Info("Running compaction on the database")
 			p.wal.CompactAll()
 		} else {
-			p.Logger.Info("CB is closed, skipping resend")
+			p.Logger.Info("CB is open, skipping resend")
 		}
 		p.resendMutex.Unlock()
 	}

--- a/pkg/servers/monitoring/server.go
+++ b/pkg/servers/monitoring/server.go
@@ -2,17 +2,29 @@ package monitoring
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/anchorfree/kafka-ambassador/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Server server.T
 
 func (s *Server) Start(configPath string) {
+	promHandler := promhttp.HandlerFor(s.Prometheus, promhttp.HandlerOpts{})
+
+	r := mux.NewRouter()
+	r.Handle("/metrics", promHandler)
+
+	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.PathPrefix("/debug/pprof").HandlerFunc(pprof.Index)
 
 	monitServer := &http.Server{
-		Handler: promhttp.HandlerFor(s.Prometheus, promhttp.HandlerOpts{}),
+		Handler: r,
 		Addr:    s.Config.GetString(configPath + ".listen"),
 	}
 


### PR DESCRIPTION
Retries were initiated even when CB was in half closed state, which was affecting RAM usage. It was decided to retry messages only when we are 100% sure CB is in ready state. This really visible when Kafka is not available for some time and we have millions of messages. 
Also some minor changes:

- enable profiling
- change logging (we have metric for this messages, no need to print)

