### PR TITLE
kafka events queue len metric

### DIFF
--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -415,6 +415,7 @@ func (p *T) kafkaStats(period time.Duration) {
 		ticker := time.NewTicker(p.Config.ResendPeriod)
 		for range ticker.C {
 			producerQueueLen.Set(float64(p.GetProducer().Producer.Len()))
+			metricKafkaEventsQueueLen.Set(float64(len(p.GetProducer().Producer.Events())))
 		}
 	}
 }

--- a/pkg/kafka/metrics.go
+++ b/pkg/kafka/metrics.go
@@ -97,6 +97,12 @@ var (
 			Help: "Kafka producer CA NotAfter",
 		},
 	)
+	metricKafkaEventsQueueLen = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "kafka_events_queue_len",
+			Help: "Kafka driver events queue length",
+		},
+	)
 )
 
 func registerMetrics(prom *prometheus.Registry) {


### PR DESCRIPTION
- Metric to monitor kafka driver events queue length